### PR TITLE
Upgrade node-problem-detector upstream image from v0.6.4 to v0.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM k8s.gcr.io/node-problem-detector:v0.6.4
+FROM k8s.gcr.io/node-problem-detector:v0.7.0
 
 RUN set -eux; \
   apt-get update; \


### PR DESCRIPTION
New in v0.7.0:
- System stats monitor
- Problems as OpenCensus metrics
- Prometheus metrics endpoint
- Plugin system for problem daemons
- Plugin system for problem exporters

Upstream release:
https://github.com/kubernetes/node-problem-detector/releases/tag/v0.7.0

Upstream changes:
https://github.com/kubernetes/node-problem-detector/compare/v0.6.4...v0.7.0