### PR TITLE
Update meta-data curl path

### DIFF
--- a/config/plugin/kiam_agent_health.sh
+++ b/config/plugin/kiam_agent_health.sh
@@ -4,7 +4,7 @@ OK=0
 NONOK=1
 UNKNOWN=2
 
-CHECK_AGENT="$(curl -s --show-error --connect-timeout 1 http://169.254.169.254/latest/meta-data/instance-id/ 2>&1)"
+CHECK_AGENT="$(curl -s --show-error --connect-timeout 1 http://169.254.169.254/latest/meta-data/instance-id/plz_give_me_id 2>&1)"
 
 case $CHECK_AGENT in
   request\ blocked*)


### PR DESCRIPTION
The AWS meta-data API will return the instance ID when any path after `http://169.254.169.254/latest/meta-data/instance-id/` is cURLed. This commit is necessary so there are not any conflicts with the Kiam agent whitelist regex.