### PR TITLE
Update meta-data url use ami-id instead of instance-id/plz_give_me_id

### DIFF
--- a/config/plugin/kiam_agent_health.sh
+++ b/config/plugin/kiam_agent_health.sh
@@ -4,7 +4,7 @@ OK=0
 NONOK=1
 UNKNOWN=2
 
-CHECK_AGENT="$(curl -s --show-error --connect-timeout 1 http://169.254.169.254/latest/meta-data/instance-id/plz_give_me_id 2>&1)"
+CHECK_AGENT="$(curl -s --show-error --connect-timeout 1 http://169.254.169.254/latest/meta-data/ami-id 2>&1)"
 
 case $CHECK_AGENT in
   request\ blocked*)
@@ -13,7 +13,7 @@ case $CHECK_AGENT in
   exit $OK
   ;;
 
-  i-*)
+  ami-*)
   # request to meta-data API is not intercepted as instance ID is obtainable
   echo "Agent does not seem to be running"
   exit $NONOK


### PR DESCRIPTION
instance-id/plz_give_me_id now returns a 404. ami-id serves the same purpose for our tests; able to retrieve an ami-id when agent isn't running and returning blocked when agent is running