### PR TITLE
change node-local-dns test from using chaos class

### DIFF
--- a/config/plugin/local_dns_resolver.sh
+++ b/config/plugin/local_dns_resolver.sh
@@ -6,12 +6,7 @@ UNKNOWN=2
 
 readonly local_dns_resolver_ip="$1"
 
-# CHAOS class request for a TXT record "id.server." (typically used for
-# identification of DNS software). We send a single attempt only, without
-# retries and with 33s timeout - CoreDNS forward plugin internally defaults to
-# 30s dial time and 2s read timeout - this way we ensure to leave enough time
-# for CoreDNS forward plugin to respond with _something_.
-dig_cmd_out="$(dig -c CH -t TXT @"${local_dns_resolver_ip}" +tries=1 +retry=0 +time=33 +norecurse +noall +noqr +comments id.server. 2>&1)"
+dig_cmd_out="$(dig -t TXT @"${local_dns_resolver_ip}" +tries=1 +retry=0 +time=33 +noqr +noall +comments kubernetes.default.svc. 2>&1)"
 dig_cmd_return_code="$?"
 dig_cmd_response_status="$(echo "${dig_cmd_out}" | grep HEADER | sed -e 's/^.* status: \(\w\w*\).*$/\1/')"
 


### PR DESCRIPTION
Removed `-c CH` (selecting chaos class request)
Removed `+norecurse` (disabling recursive query)

Tried this out by exec-ing into the pod in staging.

If dig can successfully talk to node-local-dns this should pass the test.