### PR TITLE
Handle dns check error

### DIFF
--- a/config/plugin/local_dns_resolver.sh
+++ b/config/plugin/local_dns_resolver.sh
@@ -30,6 +30,11 @@ case "${dig_cmd_return_code}" in
     exit "${NONOK}"
     ;;
 
+  10)
+    echo "Dig internal error, response status: ${dig_cmd_response_status}"
+    exit "${NONOK}"
+    ;;
+
   *)
     echo "Unexpected return code of dig: ${dig_cmd_return_code}"
     exit "${UNKNOWN}"


### PR DESCRIPTION
Dig return code 10 is an internal error. We've seen this occur on a few nodes and want to consider it an error.

https://linux.die.net/man/1/dig

```
Return Codes

Dig return codes are:

    0: Everything went well, including things like NXDOMAIN 
    1: Usage error 
    8: Couldn't open batch file 
    9: No reply from server 
    10: Internal error 
```